### PR TITLE
Mark level if trader is present in `get-book-levels`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-cli"
-version = "0.3.5"
+version = "0.3.6"
 description = "CLI and associated library for interacting with the Phoenix program from the command line"
 edition = "2021"
 license = "MIT"

--- a/src/lib/processor/process_get_book_levels.rs
+++ b/src/lib/processor/process_get_book_levels.rs
@@ -55,7 +55,6 @@ pub async fn process_get_book_levels(
     let book_bids = market.get_book(Side::Bid);
     let book_asks = market.get_book(Side::Ask);
 
-    println!("Open Bids");
     let mut open_bids = vec![];
     open_bids.push(format!(
         "{0: <20} | {1: <20} | {2: <10} | {3: <10} | {4: <15} | {5: <15} ",

--- a/src/lib/processor/process_get_book_levels.rs
+++ b/src/lib/processor/process_get_book_levels.rs
@@ -1,18 +1,128 @@
-use phoenix_sdk::sdk_client::*;
-use solana_sdk::pubkey::Pubkey;
+use std::mem::size_of;
 
-use crate::helpers::{market_helpers::get_book_levels, print_helpers::print_book};
+use phoenix::{
+    program::{load_with_dispatch, MarketHeader},
+    quantities::WrapperU64,
+    state::{markets::RestingOrder, Side},
+};
+use phoenix_sdk::sdk_client::*;
+use solana_sdk::{clock::Clock, commitment_config::CommitmentConfig, pubkey::Pubkey, sysvar};
+
+use crate::helpers::print_helpers::{print_book_with_trader, LadderLevelEntry};
 
 pub async fn process_get_book_levels(
     market_pubkey: &Pubkey,
     sdk: &SDKClient,
     levels: u64,
 ) -> anyhow::Result<()> {
-    let book = get_book_levels(market_pubkey, &sdk.client, levels).await?;
-    if book.bids.is_empty() && book.asks.is_empty() {
-        println!("Book is empty");
-    } else {
-        print_book(sdk, market_pubkey, &book)?;
+    let mut ask_entries: Vec<LadderLevelEntry> = Vec::with_capacity(levels as usize);
+    let mut bid_entries: Vec<LadderLevelEntry> = Vec::with_capacity(levels as usize);
+
+    // let meta = sdk.get_market_metadata(market_pubkey).await?;
+    // Get market account
+    let mut market_and_clock = sdk
+        .client
+        .get_multiple_accounts_with_commitment(
+            &[*market_pubkey, sysvar::clock::id()],
+            CommitmentConfig::confirmed(),
+        )
+        .await?
+        .value;
+
+    let market_account_data = market_and_clock
+        .remove(0)
+        .ok_or_else(|| anyhow::Error::msg("Market account not found"))?
+        .data;
+
+    let clock_account_data = market_and_clock
+        .remove(0)
+        .ok_or_else(|| anyhow::Error::msg("Clock account not found"))?
+        .data;
+
+    let clock: Clock = bincode::deserialize(&clock_account_data)
+        .map_err(|_| anyhow::Error::msg("Error deserializing clock"))?;
+
+    let (header_bytes, market_bytes) = market_account_data.split_at(size_of::<MarketHeader>());
+    let header: &MarketHeader = bytemuck::try_from_bytes(header_bytes)
+        .map_err(|e| anyhow::anyhow!("Error getting market header. Error: {:?}", e))?;
+
+    // Derserialize data and load into correct type
+    let market = load_with_dispatch(&header.market_size_params, market_bytes)?.inner;
+
+    // If not present, use u32::MAX instead of aborting.
+    // This will simply not print any markers.
+    let trader_index = market.get_trader_index(&sdk.trader).unwrap_or(u32::MAX);
+    let book_bids = market.get_book(Side::Bid);
+    let book_asks = market.get_book(Side::Ask);
+
+    println!("Open Bids");
+    let mut open_bids = vec![];
+    open_bids.push(format!(
+        "{0: <20} | {1: <20} | {2: <10} | {3: <10} | {4: <15} | {5: <15} ",
+        "ID", "Price (ticks)", "Price", "Quantity", "Slots Remaining", "Seconds Remaining"
+    ));
+
+    for (order_id, order) in book_bids.iter() {
+        // Check if order is expired
+        if order.is_expired(clock.slot, clock.unix_timestamp as u64) {
+            continue;
+        }
+
+        // Check if entry is present
+        if let Some(ref mut entry) = bid_entries
+            .iter_mut()
+            .find(|entry| entry.tick == order_id.price_in_ticks)
+        {
+            // If entry is present, add to amount
+            entry.lots += order.num_base_lots.as_u64();
+
+            // Flag trader if present
+            entry.trader_present |= order.trader_index == trader_index as u64;
+        }
+
+        // Otherwise, check length before attempting to add entry
+        if bid_entries.len() < levels as usize {
+            bid_entries.push(LadderLevelEntry {
+                tick: order_id.price_in_ticks.as_u64(),
+                lots: order.num_base_lots.as_u64(),
+                trader_present: order.trader_index == trader_index as u64,
+            })
+        } else {
+            break;
+        }
     }
+
+    for (order_id, order) in book_asks.iter() {
+        // Check if order is expired
+        if order.is_expired(clock.slot, clock.unix_timestamp as u64) {
+            continue;
+        }
+
+        // Check if entry is present
+        if let Some(ref mut entry) = ask_entries
+            .iter_mut()
+            .find(|entry| entry.tick == order_id.price_in_ticks)
+        {
+            // If entry is present, add to amount
+            entry.lots += order.num_base_lots.as_u64();
+
+            // Flag trader if present
+            entry.trader_present |= order.trader_index == trader_index as u64;
+        }
+
+        // Otherwise, check length before attempting to add entry
+        if ask_entries.len() < levels as usize {
+            ask_entries.push(LadderLevelEntry {
+                tick: order_id.price_in_ticks.as_u64(),
+                lots: order.num_base_lots.as_u64(),
+                trader_present: order.trader_index == trader_index as u64,
+            })
+        } else {
+            break;
+        }
+    }
+
+    print_book_with_trader(sdk, market_pubkey, &bid_entries, &ask_entries)?;
+
     Ok(())
 }

--- a/src/lib/processor/process_get_book_levels.rs
+++ b/src/lib/processor/process_get_book_levels.rs
@@ -18,7 +18,6 @@ pub async fn process_get_book_levels(
     let mut ask_entries: Vec<LadderLevelEntry> = Vec::with_capacity(levels as usize);
     let mut bid_entries: Vec<LadderLevelEntry> = Vec::with_capacity(levels as usize);
 
-    // let meta = sdk.get_market_metadata(market_pubkey).await?;
     // Get market account
     let mut market_and_clock = sdk
         .client


### PR DESCRIPTION
A little enhancement to `get-book-levels` which marks the levels in which a trader is present, e.g.

```
            21.957    5.257 ←
            21.956  180.628  
            21.954  178.555  
            21.954  183.812 ←
            21.953    5.257 ←
            21.952  112.892  
            21.951   22.578  
            21.950    2.258  
            21.948  127.574  
            21.946   12.758  
    15.063  21.938           
     2.300  21.938           
→   22.999  21.937           
   114.993  21.936           
   127.649  21.935           
→  183.989  21.932           
   178.758  21.929           
   183.989  21.919           
   191.632  21.917           
    95.855  21.908     
```

API remains the same.