### PR TITLE
Add symbols to CLI, QoL improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-cli"
-version = "0.3.6"
+version = "0.3.7"
 description = "CLI and associated library for interacting with the Phoenix program from the command line"
 edition = "2021"
 license = "MIT"

--- a/src/lib/helpers/print_helpers.rs
+++ b/src/lib/helpers/print_helpers.rs
@@ -216,12 +216,20 @@ pub fn format_float(float: f64, precision: usize) -> String {
     }
 }
 
-pub fn print_market_summary_data(market_pubkey: &Pubkey, header: &MarketHeader) {
+pub fn print_market_summary_data(
+    market_pubkey: &Pubkey,
+    header: &MarketHeader,
+    base_mint_symbol: Option<String>,
+    quote_mint_symbol: Option<String>,
+) {
     let base_pubkey = header.base_params.mint_key;
     let quote_pubkey = header.quote_params.mint_key;
 
     println!("--------------------------------------------");
-    println!("Market: {:?}", market_pubkey);
+    if let (Some(base), Some(quote)) = (base_mint_symbol, quote_mint_symbol) {
+        println!("Market: {}/{}", base, quote);
+    }
+    println!("Market Address: {:?}", market_pubkey);
     println!("Base Token: {:?}", base_pubkey);
     println!("Quote Token: {:?}", quote_pubkey);
     println!("Authority: {:?}", header.authority);
@@ -233,6 +241,8 @@ pub async fn print_market_details(
     market_metadata: &MarketMetadata,
     market_header: &MarketHeader,
     taker_fees: u64,
+    base_mint_symbol: Option<String>,
+    quote_mint_symbol: Option<String>,
 ) -> anyhow::Result<()> {
     let base_pubkey = market_metadata.base_mint;
     let quote_pubkey = market_metadata.quote_mint;
@@ -258,7 +268,10 @@ pub async fn print_market_details(
     let market = load_with_dispatch(&header.market_size_params, market_bytes)?.inner;
 
     println!("--------------------------------------------");
-    println!("Market: {}", market_pubkey);
+    if let (Some(base), Some(quote)) = (base_mint_symbol, quote_mint_symbol) {
+        println!("Market: {}/{}", base, quote);
+    }
+    println!("Market Address: {}", market_pubkey);
     println!("Status: {}", MarketStatus::from(market_header.status));
     println!("Authority: {}", market_header.authority);
     println!("Sequence number: {}", market_header.market_sequence_number);

--- a/src/lib/processor/process_get_all_markets.rs
+++ b/src/lib/processor/process_get_all_markets.rs
@@ -22,25 +22,30 @@ pub async fn process_get_all_markets(client: &EllipsisClient) -> anyhow::Result<
         let header = bytemuck::try_from_bytes::<MarketHeader>(header_bytes)
             .map_err(|e| anyhow!("Error getting market header. Error: {:?}", e))?;
 
-        let (base_mint_symbol, quote_mint_symbol) = {
-            let base_mint = header.base_params.mint_key;
-            let quote_mint = header.quote_params.mint_key;
-            (
-                config
-                    .tokens
-                    .iter()
-                    .find(|t| t.mint == base_mint.to_string())
-                    .map(|t| t.symbol.clone()),
-                config
-                    .tokens
-                    .iter()
-                    .find(|t| t.mint == quote_mint.to_string())
-                    .map(|t| t.symbol.clone()),
-            )
-        };
+        let (base_mint_symbol, quote_mint_symbol) = get_base_and_quote_symbols(&config, header);
         print_market_summary_data(&market_pubkey, header, base_mint_symbol, quote_mint_symbol);
     }
     Ok(())
+}
+
+pub fn get_base_and_quote_symbols(
+    config: &MasterConfig,
+    header: &MarketHeader,
+) -> (Option<String>, Option<String>) {
+    let base_mint = header.base_params.mint_key;
+    let quote_mint = header.quote_params.mint_key;
+    (
+        config
+            .tokens
+            .iter()
+            .find(|t| t.mint == base_mint.to_string())
+            .map(|t| t.symbol.clone()),
+        config
+            .tokens
+            .iter()
+            .find(|t| t.mint == quote_mint.to_string())
+            .map(|t| t.symbol.clone()),
+    )
 }
 
 pub async fn process_get_all_markets_no_gpa(
@@ -66,22 +71,7 @@ pub async fn process_get_all_markets_no_gpa(
         let header: &MarketHeader = bytemuck::try_from_bytes(header_bytes)
             .map_err(|e| anyhow::anyhow!("Error getting market header. Error: {:?}", e))?;
 
-        let (base_mint_symbol, quote_mint_symbol) = {
-            let base_mint = header.base_params.mint_key;
-            let quote_mint = header.quote_params.mint_key;
-            (
-                config
-                    .tokens
-                    .iter()
-                    .find(|t| t.mint == base_mint.to_string())
-                    .map(|t| t.symbol.clone()),
-                config
-                    .tokens
-                    .iter()
-                    .find(|t| t.mint == quote_mint.to_string())
-                    .map(|t| t.symbol.clone()),
-            )
-        };
+        let (base_mint_symbol, quote_mint_symbol) = get_base_and_quote_symbols(&config, header);
         print_market_summary_data(&market_pubkey, header, base_mint_symbol, quote_mint_symbol);
     }
     Ok(())

--- a/src/lib/processor/process_get_market.rs
+++ b/src/lib/processor/process_get_market.rs
@@ -4,6 +4,8 @@ use phoenix_sdk::sdk_client::*;
 use solana_sdk::pubkey::Pubkey;
 use std::mem::size_of;
 
+use super::process_get_all_markets::get_phoenix_config;
+
 pub async fn process_get_market(market_pubkey: &Pubkey, sdk: &SDKClient) -> anyhow::Result<()> {
     let market_metadata = sdk.get_market_metadata(market_pubkey).await?;
     let market_account_data = sdk.client.get_account_data(market_pubkey).await?;
@@ -18,5 +20,34 @@ pub async fn process_get_market(market_pubkey: &Pubkey, sdk: &SDKClient) -> anyh
 
     let taker_fees = market.get_taker_fee_bps();
 
-    print_market_details(sdk, market_pubkey, &market_metadata, header, taker_fees).await
+    let (base_mint_symbol, quote_mint_symbol) =
+        if let Ok(config) = get_phoenix_config(&sdk.client).await {
+            let base_mint = header.base_params.mint_key;
+            let quote_mint = header.quote_params.mint_key;
+            (
+                config
+                    .tokens
+                    .iter()
+                    .find(|t| t.mint == base_mint.to_string())
+                    .map(|t| t.symbol.clone()),
+                config
+                    .tokens
+                    .iter()
+                    .find(|t| t.mint == quote_mint.to_string())
+                    .map(|t| t.symbol.clone()),
+            )
+        } else {
+            (None, None)
+        };
+
+    print_market_details(
+        sdk,
+        market_pubkey,
+        &market_metadata,
+        header,
+        taker_fees,
+        base_mint_symbol,
+        quote_mint_symbol,
+    )
+    .await
 }

--- a/src/lib/processor/process_get_market.rs
+++ b/src/lib/processor/process_get_market.rs
@@ -4,7 +4,7 @@ use phoenix_sdk::sdk_client::*;
 use solana_sdk::pubkey::Pubkey;
 use std::mem::size_of;
 
-use super::process_get_all_markets::get_phoenix_config;
+use super::process_get_all_markets::{get_base_and_quote_symbols, get_phoenix_config};
 
 pub async fn process_get_market(market_pubkey: &Pubkey, sdk: &SDKClient) -> anyhow::Result<()> {
     let market_metadata = sdk.get_market_metadata(market_pubkey).await?;
@@ -22,20 +22,7 @@ pub async fn process_get_market(market_pubkey: &Pubkey, sdk: &SDKClient) -> anyh
 
     let (base_mint_symbol, quote_mint_symbol) =
         if let Ok(config) = get_phoenix_config(&sdk.client).await {
-            let base_mint = header.base_params.mint_key;
-            let quote_mint = header.quote_params.mint_key;
-            (
-                config
-                    .tokens
-                    .iter()
-                    .find(|t| t.mint == base_mint.to_string())
-                    .map(|t| t.symbol.clone()),
-                config
-                    .tokens
-                    .iter()
-                    .find(|t| t.mint == quote_mint.to_string())
-                    .map(|t| t.symbol.clone()),
-            )
+            get_base_and_quote_symbols(&config, header)
         } else {
             (None, None)
         };


### PR DESCRIPTION
Huge QoL improvement to CLI. Previously there were no symbols in the command output

get-all-markets
![image](https://github.com/Ellipsis-Labs/phoenix-cli/assets/61092285/f6d26442-1209-465b-bc94-04434b3c1e6c)

get-market
![image](https://github.com/Ellipsis-Labs/phoenix-cli/assets/61092285/64df38b6-301a-4c4e-8eff-9ef805071f92)
