### PR TITLE
Add uncollected revenue cmd

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -85,4 +85,6 @@ pub enum PhoenixCLICommand {
         market_pubkey: Pubkey,
         trader_to_evict: Option<Pubkey>,
     },
+    /// Retrieves the current uncollected revenue, denominated in USDC, from the mainnet-beta markets.
+    GetUncollectedRevenue,
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -85,6 +85,7 @@ pub enum PhoenixCLICommand {
         market_pubkey: Pubkey,
         trader_to_evict: Option<Pubkey>,
     },
-    /// Retrieves the current uncollected revenue, denominated in USDC, from the mainnet-beta markets.
+    /// Retrieves the current uncollected revenue grouped by USDC, USDT, and SOL,
+    /// as well as the total denominated in USDC.
     GetUncollectedRevenue,
 }

--- a/src/lib/processor/mod.rs
+++ b/src/lib/processor/mod.rs
@@ -14,3 +14,4 @@ pub mod process_get_transaction;
 pub mod process_mint_tokens;
 pub mod process_mint_tokens_for_market;
 pub mod process_request_seat;
+pub mod process_get_uncollected_revenue;

--- a/src/lib/processor/process_get_uncollected_revenue.rs
+++ b/src/lib/processor/process_get_uncollected_revenue.rs
@@ -1,0 +1,94 @@
+use std::{collections::HashMap, mem::size_of, str::FromStr};
+
+use anyhow::anyhow;
+use ellipsis_client::EllipsisClient;
+use phoenix::{
+    program::{load_with_dispatch, MarketHeader},
+    quantities::WrapperU64,
+};
+use phoenix_sdk::sdk_client::SDKClient;
+use serde_json::Value;
+use solana_sdk::pubkey::Pubkey;
+
+use super::process_get_all_markets::{get_base_and_quote_symbols, get_phoenix_config};
+
+pub async fn process_get_uncollected_revenue(
+    client: &EllipsisClient,
+    network_url: &str,
+) -> anyhow::Result<()> {
+    let config = get_phoenix_config(client).await?;
+    let markets = config
+        .markets
+        .iter()
+        .map(|m| m.market.clone())
+        .collect::<Vec<String>>()
+        .clone();
+
+    let mut sdk = SDKClient::new(&client.payer, network_url).await?;
+
+    let usdtprice = get_price("USDT", "USDC").await?;
+    let solprice = get_price("SOL", "USDC").await?;
+
+    println!("Retrieving current balances...");
+    let mut total_usdc = 0f32;
+    let mut total_usdt = 0f32;
+    let mut total_sol = 0f32;
+    let mut total = 0f32;
+    for market_key in markets {
+        let market_pubkey = &Pubkey::from_str(&market_key)?;
+        sdk.add_market(&market_pubkey).await?;
+        let market_metadata = sdk.get_market_metadata(market_pubkey).await?;
+
+        let market_account_data = sdk.client.get_account_data(&market_pubkey).await?;
+        let (header_bytes, market_bytes) = market_account_data.split_at(size_of::<MarketHeader>());
+        let header: &MarketHeader = bytemuck::try_from_bytes(header_bytes)
+            .map_err(|e| anyhow::anyhow!("Error getting market header. Error: {:?}", e))?;
+
+        let market = load_with_dispatch(&header.market_size_params, market_bytes)
+            .map_err(|e| anyhow::anyhow!("Failed to load market. Error {:?}", e))?
+            .inner;
+
+        let (_, quote_mint_symbol) = get_base_and_quote_symbols(&config, header);
+        let quote_mint_symbol = quote_mint_symbol.unwrap();
+        let quote_mint_symbol = quote_mint_symbol.as_str();
+
+        let amt = market.get_uncollected_fee_amount().as_u64() as f32
+            / 10f32.powi(market_metadata.quote_decimals as i32);
+        match quote_mint_symbol {
+            "USDC" => {
+                total_usdc += amt;
+                total += amt;
+            }
+            "USDT" => {
+                total_usdt += amt;
+                total += usdtprice * amt;
+            }
+            "SOL" => {
+                total_sol += amt;
+                total += solprice * amt;
+            }
+            _ => return Err(anyhow!(
+                "The {market_key} market is using an unsupported quote token: {quote_mint_symbol}."
+            )),
+        }
+    }
+    println!("USDC Bal: {total_usdc}");
+    println!("USDT Bal: {total_usdt}");
+    println!("SOL Bal: {total_sol}");
+    println!("Total Bal (USDC): {total}");
+    Ok(())
+}
+
+async fn get_price(symbol_a: &str, symbol_b: &str) -> anyhow::Result<f32> {
+    let body = reqwest::get(format!(
+        "https://api.coinbase.com/v2/prices/{symbol_a}-{symbol_b}/spot"
+    ))
+    .await?
+    .json::<HashMap<String, Value>>()
+    .await?;
+    //TODO: fail gracefully
+    let price = &body["data"]["amount"].as_str().unwrap();
+    price
+        .parse::<f32>()
+        .map_err(|e| anyhow!("Failed to get price, Error {e}"))
+}

--- a/src/lib/processor/process_get_uncollected_revenue.rs
+++ b/src/lib/processor/process_get_uncollected_revenue.rs
@@ -72,10 +72,10 @@ pub async fn process_get_uncollected_revenue(
             )),
         }
     }
-    println!("USDC Bal: {total_usdc}");
-    println!("USDT Bal: {total_usdt}");
-    println!("SOL Bal: {total_sol}");
-    println!("Total Bal (USDC): {total}");
+    println!("USDC: {total_usdc}");
+    println!("USDT: {total_usdt}");
+    println!("SOL: {total_sol}");
+    println!("Total (USDC): {total}");
     Ok(())
 }
 
@@ -83,11 +83,10 @@ async fn get_price(symbol_a: &str, symbol_b: &str) -> anyhow::Result<f32> {
     let body = reqwest::get(format!(
         "https://api.coinbase.com/v2/prices/{symbol_a}-{symbol_b}/spot"
     ))
-    .await?
+    .await.map_err(|_| anyhow!("Failed to get price data, looks like Coinbase is down.."))?
     .json::<HashMap<String, Value>>()
     .await?;
-    //TODO: fail gracefully
-    let price = &body["data"]["amount"].as_str().unwrap();
+    let price = &body["data"]["amount"].as_str().unwrap(); //fails if coinbase changes their format
     price
         .parse::<f32>()
         .map_err(|e| anyhow!("Failed to get price, Error {e}"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,7 @@ use ellipsis_client::EllipsisClient;
 use phoenix_cli_processor::processor::process_claim_seat::process_claim_seat;
 use phoenix_cli_processor::processor::process_evict_seat::process_evict_seat;
 use phoenix_cli_processor::processor::{
-    process_get_all_markets::*, process_get_book_levels::*, process_get_full_book::*,
-    process_get_market::*, process_get_market_status::*, process_get_open_orders::*,
-    process_get_seat_info::*, process_get_seat_manager_info::*, process_get_top_of_book::*,
-    process_get_traders_for_market::*, process_get_transaction::*, process_mint_tokens::*,
-    process_mint_tokens_for_market::*, process_request_seat::*,
+    process_get_all_markets::*, process_get_book_levels::*, process_get_full_book::*, process_get_market::*, process_get_market_status::*, process_get_open_orders::*, process_get_seat_info::*, process_get_seat_manager_info::*, process_get_top_of_book::*, process_get_traders_for_market::*, process_get_transaction::*, process_mint_tokens::*, process_mint_tokens_for_market::*, process_request_seat::*, process_get_uncollected_revenue::*
 };
 use phoenix_sdk::sdk_client::*;
 use solana_cli_config::{Config, ConfigInput, CONFIG_FILE};
@@ -171,6 +167,9 @@ async fn main() -> anyhow::Result<()> {
         } => {
             sdk.add_market(&market_pubkey).await?;
             process_evict_seat(&sdk.client, &market_pubkey, &trader_to_evict).await?
+        }
+        PhoenixCLICommand::GetUncollectedRevenue => {
+            process_get_uncollected_revenue(&client, network_url).await?;
         }
     }
 


### PR DESCRIPTION
Adds a new subcommand to the cli: `get-uncollected-revenue`

It retrieves the total uncollected balance of all markets in the passed url (falls back to defaults the same as the other commands). It groups balances by their quote denomination (i.e. USDT, USDC, and SOL). It also prints the sum of all balances denominated in USDC.