### PR TITLE
Rename Phoenix to Phoenix Legacy in docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phoenix-cli"
 version = "0.3.14"
-description = "CLI and associated library for interacting with the Phoenix program from the command line"
+description = "CLI and associated library for interacting with the Phoenix Legacy program from the command line"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # phoenix-cli
-CLI for interacting with the Phoenix DEX
+CLI for interacting with the Phoenix Legacy DEX
 
 ## Program Deployments
 
 | Program     | Devnet                                         | 
 | ----------- | ---------------------------------------------- |
-| Phoenix Dex | `PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY`  |
+| Phoenix Legacy DEX | `PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY`  |
 
 | Program     | Mainnet                                        | 
 | ----------- | ---------------------------------------------- |
-| Phoenix Dex | `PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY`  |
+| Phoenix Legacy DEX | `PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY`  |
 
 ## Installation 
 
@@ -20,7 +20,7 @@ Run the following command in your shell to install it (or visit https://rustup.r
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-To install the Phoenix CLI, run the following in your shell:
+To install the Phoenix Legacy CLI, run the following in your shell:
 
 ```
 cargo install phoenix-cli
@@ -43,7 +43,7 @@ Optionally include the following parameters when running the cli:
 
 
 ### get-all-markets
-Returns summary information on all markets that exist on Phoenix. Summary information includes market key, base and quote token keys, and authority key. Recommended to use the no-gpa flag to read from a static config file and avoiding making an expensive network call.
+Returns summary information on all markets that exist on Phoenix Legacy. Summary information includes market key, base and quote token keys, and authority key. Recommended to use the no-gpa flag to read from a static config file and avoiding making an expensive network call.
 
 `$ phoenix-cli -u main get-all-markets --no-gpa`
 ```
@@ -226,7 +226,6 @@ Creating ATA for base token
 Creating ATA for quote token
 Tokens minted! Signature: 2mN6o7gBB41UFEboQuCMaeG1t5qQ1uRAvTDoXUhsk1yBoKXQtrXsHVtkQAT9R3oRUSPbhDkZjCQtNtjcYP4TqwVV
 ```
-
 
 
 

--- a/phoenix-cli-install.sh
+++ b/phoenix-cli-install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Phoenix CLI binary installation script
+# Phoenix Legacy CLI binary installation script
 #
 # The purpose of this script is to automate the download and installation
-# of Phoenix CLI binary.
+# of Phoenix Legacy CLI binary.
 # 
 # Currently the supported platforms are macOS, Linux
 #
@@ -19,7 +19,7 @@ abort_on_error() {
     fi
 }
 
-CYN  "Phoenix CLI installation script"
+CYN  "Phoenix Legacy CLI installation script"
 echo "---------------------------------------"
 echo ""
 
@@ -69,7 +69,7 @@ abort_on_error $?
 SIZE=$(wc -c "$SOURCE/$DIST" | grep -oE "[0-9]+" | head -n 1)
 
 if [ $SIZE -eq 0 ]; then
-    RED "Aborting: could not download Phoenix distribution"
+    RED "Aborting: could not download Phoenix Legacy distribution"
     exit 1
 fi
 
@@ -86,7 +86,7 @@ if [ ! "$(command -v $BIN)" = "" ]; then
     # replace it
     EXISTING="$(which $BIN)"
 
-    echo "Phoenix binary was found at:"
+    echo "Phoenix Legacy binary was found at:"
     echo "  => $(CYN $EXISTING)"
     echo ""
     echo -n "$(CYN "Replace it? [y/n]") (default 'n'): "


### PR DESCRIPTION
Update user-facing docs and installer messaging to use Phoenix Legacy. Adjust package description to match the new branding.